### PR TITLE
npm run formatのエラーを解消

### DIFF
--- a/.prettierrc.config.js
+++ b/.prettierrc.config.js
@@ -1,8 +1,8 @@
 module.exports = {
-  trailingComma: 'all', // 末尾のカンマあり
+  trailingComma: "all", // 末尾のカンマあり
   tabWidth: 2, // tab の長さは半角スペース 2 つ
   semi: true, // セミコロンあり
   singleQuote: true, // シングルクォーテーションに統一
   jsxSingleQuote: true, //jsx もシングルクォーテーションに統一
-  plugins: [require('prettier-plugin-tailwindcss')],
+  plugins: [require("prettier-plugin-tailwindcss")],
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "lint:fix": "eslint app features --ext .js,jsx,.ts,.tsx --fix",
     "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'",
-    "format alt": "prettier --write --ignore-path .gitignore ./**/*.{js,jsx,ts,tsx,json,css}"
+    "format-alt": "prettier --write --ignore-path .gitignore ./**/*.{js,jsx,ts,tsx,json,css}"
   },
   "dependencies": {
     "autoprefixer": "10.4.14",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "eslint app features --ext .js,jsx,.ts,.tsx --fix",
-    "format": "prettier --write --ignore-path .gitignore ./**/*.{js,jsx,ts,tsx,json,css}"
+    "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'",
+    "format alt": "prettier --write --ignore-path .gitignore ./**/*.{js,jsx,ts,tsx,json,css}"
   },
   "dependencies": {
     "autoprefixer": "10.4.14",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "eslint app features --ext .js,jsx,.ts,.tsx --fix",
-    "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'"
+    "format": "prettier --write --ignore-path .gitignore ./**/*.{js,jsx,ts,tsx,json,css}"
   },
   "dependencies": {
     "autoprefixer": "10.4.14",


### PR DESCRIPTION
## チェックリスト

- [x] マージ元のブランチが正しいか(自分の作成したブランチか)
- [x] マージ先のブランチが正しいか(基本はmain)
- [x] 不必要なコードを削除する(コマンドラインからPushする場合)
- [x] lintを実行する（npm run format）
- [x] プルリクエストの名前を変更する
- [x] 下の欄を埋める

# 概要
prettierが動作するように修正

### 実装したところ
`package.json`の11行目のシングルクォーテーションを削除したを12行目に`format-alt`として追加
`.prettierrc.js`->`.prettierrc.config.js`（保存した時にprettierが走ってシングルクォートがダブルクォートになった）

### 懸念点
現状でも動いているという人もいるので，この変更によるメリットよりデメリットの方が大きいかもしれない．

### 関連するIssue([Closes #数字]で選択可能)
