### PR TITLE
登録ページとログインページにリダイレクトの機能を追加

### DIFF
--- a/app/login/page.js
+++ b/app/login/page.js
@@ -1,60 +1,76 @@
-"use client";
+'use client';
 
-import { useState } from "react";
+import { useState } from 'react';
 import 'whatwg-fetch';
 
 export default function Login() {
-  let [email, setEmail] = useState("");
-  let [password, setPassword] = useState("");
+  let [email, setEmail] = useState('');
+  let [password, setPassword] = useState('');
   return (
     <main>
-      <div> 
+      <div>
         <div>
           <label>メールアドレス</label>
-          <input className="ring-2" type="email" value={email} onChange={(event) => setEmail(event.target.value)} />
+          <input
+            className='ring-2'
+            type='email'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
         </div>
         <div>
           <label>パスワード</label>
-          <input className="ring-2" type="password" value={password} onChange={(event) => setPassword(event.target.value)}/>
+          <input
+            className='ring-2'
+            type='password'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
         </div>
-        <button onClick={()=>onClickLoginPageSendButton({email,password})} className = "bg-thin">送信</button>
+        <button
+          onClick={() => onClickLoginPageSendButton({ email, password })}
+          className='bg-thin'
+        >
+          送信
+        </button>
       </div>
     </main>
   );
 }
 
-function onClickLoginPageSendButton({email,password}){
+function onClickLoginPageSendButton({ email, password }) {
   fetch(`${process.env.NEXT_PUBLIC_URL}/login`, {
     method: 'POST',
-    mode:"cors",
+    mode: 'cors',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       email: email,
       password: password,
+    }),
+  })
+    .then(function (response) {
+      return response.json();
     })
-  }).then(function(response) {
-    return response.json();
-  })
-  .then(function(data){
-    if (!navigator.cookieEnabled) {
-      alert('cookieを有効にしてください');
-      return;
-    }
+    .then(function (data) {
+      if (!navigator.cookieEnabled) {
+        alert('cookieを有効にしてください');
+        return;
+      }
 
-    // cookieに情報がない場合
-    if(!document.cookie) {
-      document.cookie = JSON.stringify({'token': data.token});
-    }
-    // cookieに情報がある場合
-    else {
-      const cookieAsJson = JSON.parse(document.cookie);
-      cookieAsJson.token = data.token;
-      document.cookie = JSON.stringify(cookieAsJson);
-    }
-  })
- .catch(function(error) {
-    console.error(error);
- });
+      // cookieに情報がない場合
+      if (!document.cookie) {
+        document.cookie = JSON.stringify({ token: data.token });
+      }
+      // cookieに情報がある場合
+      else {
+        const cookieAsJson = JSON.parse(document.cookie);
+        cookieAsJson.token = data.token;
+        document.cookie = JSON.stringify(cookieAsJson);
+      }
+    })
+    .catch(function (error) {
+      console.error(error);
+    });
 }

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -1,6 +1,5 @@
 "use client";
 
-import { cookies } from "next/dist/client/components/headers";
 import { useState } from "react";
 import 'whatwg-fetch';
 
@@ -25,7 +24,7 @@ export default function Login() {
 }
 
 function onClickLoginPageSendButton({email,password}){
-  fetch(process.env.NEXT_PUBLIC_URL+'/login', {
+  fetch(`${process.env.NEXT_PUBLIC_URL}/login`, {
     method: 'POST',
     mode:"cors",
     headers: {
@@ -42,7 +41,7 @@ function onClickLoginPageSendButton({email,password}){
     if (!navigator.cookieEnabled) {
       alert('cookieを有効にしてください');
       return;
-    };
+    }
 
     // cookieに情報がない場合
     if(!document.cookie) {
@@ -54,7 +53,6 @@ function onClickLoginPageSendButton({email,password}){
       cookieAsJson.token = data.token;
       document.cookie = JSON.stringify(cookieAsJson);
     }
-    console.log(document.cookie);
   })
  .catch(function(error) {
     console.error(error);

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -1,33 +1,47 @@
-"use client";
+'use client';
 
-import postLoginRequest from "@/features/auth/data/PostLoginRequest";
-import { useState } from "react";
+import postLoginRequest from '@/features/auth/data/PostLoginRequest';
+import { useState } from 'react';
 import 'whatwg-fetch';
 import { useRouter } from 'next/navigation';
 
 export default function Login() {
   const router = useRouter();
-  let [email, setEmail] = useState("");
-  let [password, setPassword] = useState("");
+  let [email, setEmail] = useState('');
+  let [password, setPassword] = useState('');
   return (
     <main>
-      <div> 
+      <div>
         <div>
           <label>メールアドレス</label>
-          <input className="ring-2" type="email" value={email} onChange={(event) => setEmail(event.target.value)} />
+          <input
+            className='ring-2'
+            type='email'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
         </div>
         <div>
           <label>パスワード</label>
-          <input className="ring-2" type="password" value={password} onChange={(event) => setPassword(event.target.value)}/>
+          <input
+            className='ring-2'
+            type='password'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
         </div>
-        <button onClick={async ()=> {
-          const isSuccess = await postLoginRequest(email, password);
-          if (isSuccess) {
-            router.push(`/destinations`);
-          }
-          }} className = "bg-thin">送信</button>
+        <button
+          className='bg-thin'
+          onClick={async () => {
+            const isSuccess = await postLoginRequest(email, password);
+            if (isSuccess) {
+              router.push(`/destinations`);
+            }
+          }}
+        >
+          送信
+        </button>
       </div>
     </main>
   );
 }
-

--- a/app/register/page.js
+++ b/app/register/page.js
@@ -42,14 +42,14 @@ export default function Register() {
         </div>
         <button
           onClick={async () => {
-            const isRegisterSuccess = await PostRegisterRequest(
+            const isSuccessToRegister = await PostRegisterRequest(
               email,
               loginPassword,
               emailPassword,
             );
-            if (!isRegisterSuccess) return;
-            const isLoginSuccess = postLoginRequest(email, loginPassword);
-            if (!isLoginSuccess) return;
+            if (!isSuccessToRegister) return;
+            const isSuccessToLogin = postLoginRequest(email, loginPassword);
+            if (!isSuccessToLogin) return;
             router.push(`/destinations`);
           }}
           className='bg-thin'

--- a/app/register/page.js
+++ b/app/register/page.js
@@ -1,39 +1,61 @@
-"use client";
+'use client';
 
-import postLoginRequest from "@/features/auth/data/PostLoginRequest";
-import PostRegisterRequest from "@/features/auth/data/PostRegisterRequest";
-import { useState } from "react";
+import postLoginRequest from '@/features/auth/data/PostLoginRequest';
+import PostRegisterRequest from '@/features/auth/data/PostRegisterRequest';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 export default function Register() {
   const router = useRouter();
-  let [email, setEmail] = useState("");
-  let [loginPassword, setLoginPassword] = useState("");
-  let [emailPassword, setEmailPassword] = useState("");
+  let [email, setEmail] = useState('');
+  let [loginPassword, setLoginPassword] = useState('');
+  let [emailPassword, setEmailPassword] = useState('');
   return (
     <main>
-      <div> 
+      <div>
         <div>
           <label>メールアドレス</label>
-          <input className="ring-2" type="email" value={email} onChange={(event) => setEmail(event.target.value)} />
+          <input
+            className='ring-2'
+            type='email'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
         </div>
         <div>
           <label>ログインパスワード</label>
-          <input className="ring-2" type="password" value={loginPassword} onChange={(event) => setLoginPassword(event.target.value)}/>
+          <input
+            className='ring-2'
+            type='password'
+            value={loginPassword}
+            onChange={(event) => setLoginPassword(event.target.value)}
+          />
         </div>
         <div>
           <label>メールパスワード</label>
-          <input className="ring-2" type="password" value={emailPassword} onChange={(event) => setEmailPassword(event.target.value)}/>
+          <input
+            className='ring-2'
+            type='password'
+            value={emailPassword}
+            onChange={(event) => setEmailPassword(event.target.value)}
+          />
         </div>
-        <button onClick={async ()=> {
-             const isRegisterSuccess = await PostRegisterRequest(email,loginPassword,emailPassword);
-              if(!isRegisterSuccess)
-              return; 
-              const isLoginSuccess = postLoginRequest(email, loginPassword);
-              if (!isLoginSuccess)
-              return;
-              router.push(`/destinations`);
-          }} className = "bg-thin">送信</button>
+        <button
+          onClick={async () => {
+            const isRegisterSuccess = await PostRegisterRequest(
+              email,
+              loginPassword,
+              emailPassword,
+            );
+            if (!isRegisterSuccess) return;
+            const isLoginSuccess = postLoginRequest(email, loginPassword);
+            if (!isLoginSuccess) return;
+            router.push(`/destinations`);
+          }}
+          className='bg-thin'
+        >
+          送信
+        </button>
       </div>
     </main>
   );

--- a/features/auth/data/PostLoginRequest.js
+++ b/features/auth/data/PostLoginRequest.js
@@ -1,36 +1,37 @@
 export default async function postLoginRequest(email, password) {
-    return fetch(`${process.env.NEXT_PUBLIC_URL}/login`, {
-        method: 'POST',
-        mode:"cors",
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          email: email,
-          password: password,
-        })
-      }).then(function(response) {
-        return response.json();
-      })
-      .then(function(data){
-        if (!navigator.cookieEnabled) {
-          alert('cookieを有効にしてください');
-          return false;
-        }
-    
-        // cookieに情報がない場合
-        if(!document.cookie) {
-          document.cookie = JSON.stringify({'token': data.token});
-        }
-        // cookieに情報がある場合
-        else {
-          const cookieAsJson = JSON.parse(document.cookie);
-          cookieAsJson.token = data.token;
-          document.cookie = JSON.stringify(cookieAsJson);
-        }
-        return true;
-      })
-     .catch(function(error) {
-        console.error(error);
-     });
+  return fetch(`${process.env.NEXT_PUBLIC_URL}/login`, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: email,
+      password: password,
+    }),
+  })
+    .then(function (response) {
+      return response.json();
+    })
+    .then(function (data) {
+      if (!navigator.cookieEnabled) {
+        alert('cookieを有効にしてください');
+        return false;
+      }
+
+      // cookieに情報がない場合
+      if (!document.cookie) {
+        document.cookie = JSON.stringify({ token: data.token });
+      }
+      // cookieに情報がある場合
+      else {
+        const cookieAsJson = JSON.parse(document.cookie);
+        cookieAsJson.token = data.token;
+        document.cookie = JSON.stringify(cookieAsJson);
+      }
+      return true;
+    })
+    .catch(function (error) {
+      console.error(error);
+    });
 }

--- a/features/auth/data/PostRegisterRequest.js
+++ b/features/auth/data/PostRegisterRequest.js
@@ -1,23 +1,27 @@
-export default async function PostRegisterRequest(email, loginPassword, emailPassword){
-    return fetch(`${process.env.NEXT_PUBLIC_URL}/register`, {
-      method: 'POST',
-      mode:"cors",
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        email: email,
-        login_password: loginPassword,
-        mail_password: emailPassword
-      })
-    }).then(function(response) {
+export default async function PostRegisterRequest(
+  email,
+  loginPassword,
+  emailPassword,
+) {
+  return fetch(`${process.env.NEXT_PUBLIC_URL}/register`, {
+    method: 'POST',
+    mode: 'cors',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: email,
+      login_password: loginPassword,
+      mail_password: emailPassword,
+    }),
+  })
+    .then(function (response) {
       return response.json();
-     })
-     .then(function(data){
+    })
+    .then(function (data) {
       return data.is_success;
     })
-   .catch(function(error) {
+    .catch(function (error) {
       console.error(error);
-   });
-  }
-  
+    });
+}


### PR DESCRIPTION
## チェックリスト

- [x] マージ元のブランチが正しいか(自分の作成したブランチか)
- [x] マージ先のブランチが正しいか(基本はmain)
- [ ] 不必要なコードを削除する(コマンドラインからPushする場合)
- [ ] lintを実行する（npm run format）
- [x] プルリクエストの名前を変更する
- [x] 下の欄を埋める

# 概要
登録ページやログインページにてリダイレクトの機能を追加
### 実装したところ
feature/auth/data, app/login, app/register
### 懸念点
aysncやawaitの理解が怪しいので正しく使えているか不安
### 関連するIssue([Closes #数字]で選択可能)
無し